### PR TITLE
Add XDG support

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -188,8 +188,8 @@ Path Path::cwd() {
 }
 
 Path Path::home() {
-	const char *tmp{getenv("XDG_CONFIG_HOME")};
-	String p{};
+	const char *tmp = getenv("XDG_CONFIG_HOME");
+	String p = "";
 
 	if (!tmp) {
 		p = getenv("HOME");

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3,6 +3,7 @@
 #include "system.h"
 #include "sync.h"
 #include "hash.h"
+#include <cstdlib>
 
 
 #ifdef WINDOWS
@@ -188,8 +189,19 @@ Path Path::cwd() {
 }
 
 Path Path::home() {
-	Path r(getenv("HOME"));
+	const char *tmp{getenv("XDG_CONFIG_HOME")};
+	String p{};
+
+	if (!tmp) {
+		p = getenv("HOME");
+		p.append("/.config");
+	} else {
+		p = tmp;
+	}
+
+	Path r(p + "/mymake");
 	r.makeDir();
+	r.createDir();
 	return r;
 }
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3,7 +3,6 @@
 #include "system.h"
 #include "sync.h"
 #include "hash.h"
-#include <cstdlib>
 
 
 #ifdef WINDOWS


### PR DESCRIPTION
Add support for following XDG spec for the global configuration file. 
Fall back to $HOME/.config/mymake if $XDG_CONFIG_HOME is unset.